### PR TITLE
Add configuration file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,3 +58,34 @@ print(result.response)
 Set any required API keys (e.g. ``OPENAI_API_KEY``) or service URLs in your
 environment variables to activate the chosen backend.
 
+## Configuration file
+
+Agents can optionally read connection details for external systems from a YAML
+configuration file. The orchestrator automatically loads ``ops_config.yml`` from
+the project root or the path specified by the ``OPS_CONFIG_FILE`` environment
+variable. A sample configuration might look like:
+
+```yaml
+database:
+  connection_string: postgresql://user:pass@localhost/db
+jira:
+  url: https://jira.example.com
+github:
+  token: ghp_exampletoken
+servicenow:
+  url: https://servicenow.example.com
+```
+
+Pass the loaded configuration to agents or let the ``Orchestrator`` do so
+automatically:
+
+```python
+from ops_agents import Orchestrator, load_config
+
+config = load_config()
+orch = Orchestrator(config=config)
+```
+
+Each agent receives the configuration object and can use the values to connect
+to databases, JIRA, GitHub or ServiceNow.
+

--- a/ops_agents/__init__.py
+++ b/ops_agents/__init__.py
@@ -1,6 +1,7 @@
 """Operational intelligence multi-agent framework."""
 
 from .orchestrator import Orchestrator, OrchestrationResult
+from .config import Config, load_config
 from .log_agent import LogAgent
 from .code_agent import CodeAgent
 from .database_agent import DatabaseAgent
@@ -29,4 +30,6 @@ __all__ = [
     "CrewAILLM",
     "SemanticKernelLLM",
     "AzureOpenAILLM",
+    "Config",
+    "load_config",
 ]

--- a/ops_agents/code_agent.py
+++ b/ops_agents/code_agent.py
@@ -1,13 +1,15 @@
 from .base import Agent
 from .llm import LLM, OpenAILLM
+from .config import Config
 
 
 class CodeAgent(Agent):
     """Agent responsible for code analysis or generation."""
 
-    def __init__(self, llm: LLM | None = None):
+    def __init__(self, llm: LLM | None = None, config: Config | None = None):
         super().__init__("code")
         self.llm = llm or OpenAILLM()
+        self.config = config
 
     def run(self, prompt: str) -> str:
         query = f"Assist with code for: {prompt}"

--- a/ops_agents/config.py
+++ b/ops_agents/config.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+"""Configuration loader for external service connections."""
+
+from dataclasses import dataclass
+import os
+import yaml
+
+
+@dataclass
+class Config:
+    """Configuration values for external service connections."""
+
+    database_url: str | None = None
+    jira_url: str | None = None
+    github_token: str | None = None
+    servicenow_url: str | None = None
+
+
+def load_config(path: str | None = None) -> Config:
+    """Load configuration from a YAML file.
+
+    The file path can be provided explicitly or via the ``OPS_CONFIG_FILE``
+    environment variable. If no file is found, an empty ``Config`` object is
+    returned.
+    """
+    path = path or os.getenv("OPS_CONFIG_FILE", "ops_config.yml")
+    if not os.path.exists(path):
+        return Config()
+    with open(path, "r") as f:
+        data = yaml.safe_load(f) or {}
+    return Config(
+        database_url=data.get("database", {}).get("connection_string"),
+        jira_url=data.get("jira", {}).get("url"),
+        github_token=data.get("github", {}).get("token"),
+        servicenow_url=data.get("servicenow", {}).get("url"),
+    )

--- a/ops_agents/database_agent.py
+++ b/ops_agents/database_agent.py
@@ -1,13 +1,15 @@
 from .base import Agent
 from .llm import LLM, OpenAILLM
+from .config import Config
 
 
 class DatabaseAgent(Agent):
     """Agent responsible for database queries or analysis."""
 
-    def __init__(self, llm: LLM | None = None):
+    def __init__(self, llm: LLM | None = None, config: Config | None = None):
         super().__init__("database")
         self.llm = llm or OpenAILLM()
+        self.config = config
 
     def run(self, prompt: str) -> str:
         query = f"Handle database task: {prompt}"

--- a/ops_agents/incident_agent.py
+++ b/ops_agents/incident_agent.py
@@ -1,13 +1,15 @@
 from .base import Agent
 from .llm import LLM, OpenAILLM
+from .config import Config
 
 
 class IncidentAgent(Agent):
     """Agent responsible for incident management."""
 
-    def __init__(self, llm: LLM | None = None):
+    def __init__(self, llm: LLM | None = None, config: Config | None = None):
         super().__init__("incident")
         self.llm = llm or OpenAILLM()
+        self.config = config
 
     def run(self, prompt: str) -> str:
         query = f"Investigate incident: {prompt}"

--- a/ops_agents/jira_agent.py
+++ b/ops_agents/jira_agent.py
@@ -1,13 +1,15 @@
 from .base import Agent
 from .llm import LLM, OpenAILLM
+from .config import Config
 
 
 class JiraAgent(Agent):
     """Agent responsible for JIRA ticket management."""
 
-    def __init__(self, llm: LLM | None = None):
+    def __init__(self, llm: LLM | None = None, config: Config | None = None):
         super().__init__("jira")
         self.llm = llm or OpenAILLM()
+        self.config = config
 
     def run(self, prompt: str) -> str:
         query = f"Work with JIRA: {prompt}"

--- a/ops_agents/log_agent.py
+++ b/ops_agents/log_agent.py
@@ -1,13 +1,15 @@
 from .base import Agent
 from .llm import LLM, OpenAILLM
+from .config import Config
 
 
 class LogAgent(Agent):
     """Agent responsible for log analysis."""
 
-    def __init__(self, llm: LLM | None = None):
+    def __init__(self, llm: LLM | None = None, config: Config | None = None):
         super().__init__("log")
         self.llm = llm or OpenAILLM()
+        self.config = config
 
     def run(self, prompt: str) -> str:
         # In reality this would parse and analyze logs

--- a/ops_agents/orchestrator.py
+++ b/ops_agents/orchestrator.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 
 from .base import Agent
 from .llm import LLM, OpenAILLM
+from .config import Config, load_config
 from .log_agent import LogAgent
 from .code_agent import CodeAgent
 from .database_agent import DatabaseAgent
@@ -20,13 +21,14 @@ class OrchestrationResult:
 class Orchestrator:
     """Route a prompt to the appropriate agent based on simple heuristics."""
 
-    def __init__(self, llm: LLM | None = None):
+    def __init__(self, llm: LLM | None = None, config: Config | None = None):
         llm = llm or OpenAILLM()
-        self.log_agent = LogAgent(llm=llm)
-        self.code_agent = CodeAgent(llm=llm)
-        self.db_agent = DatabaseAgent(llm=llm)
-        self.incident_agent = IncidentAgent(llm=llm)
-        self.jira_agent = JiraAgent(llm=llm)
+        self.config = config or load_config()
+        self.log_agent = LogAgent(llm=llm, config=self.config)
+        self.code_agent = CodeAgent(llm=llm, config=self.config)
+        self.db_agent = DatabaseAgent(llm=llm, config=self.config)
+        self.incident_agent = IncidentAgent(llm=llm, config=self.config)
+        self.jira_agent = JiraAgent(llm=llm, config=self.config)
 
     def dispatch(self, prompt: str) -> OrchestrationResult:
         lowered = prompt.lower()

--- a/ops_config.yml
+++ b/ops_config.yml
@@ -1,0 +1,8 @@
+database:
+  connection_string: postgresql://user:pass@localhost/db
+jira:
+  url: https://jira.example.com
+github:
+  token: ghp_exampletoken
+servicenow:
+  url: https://servicenow.example.com

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,28 @@
+import os
+import tempfile
+from ops_agents import load_config
+
+
+def test_load_config_from_file():
+    yaml_content = """
+    database:
+      connection_string: sqlite:///tmp.db
+    jira:
+      url: https://jira.local
+    github:
+      token: testtoken
+    servicenow:
+      url: https://sn.local
+    """
+    with tempfile.NamedTemporaryFile('w+', delete=False) as f:
+        f.write(yaml_content)
+        path = f.name
+    try:
+        cfg = load_config(path)
+        assert cfg.database_url == "sqlite:///tmp.db"
+        assert cfg.jira_url == "https://jira.local"
+        assert cfg.github_token == "testtoken"
+        assert cfg.servicenow_url == "https://sn.local"
+    finally:
+        os.remove(path)
+

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,5 +1,5 @@
 import pytest
-from ops_agents import Orchestrator
+from ops_agents import Orchestrator, Config
 
 class FakeLLM:
     def __init__(self):
@@ -55,3 +55,13 @@ def test_agent_query_used():
     assert result.agent == "log"
     assert orch.log_agent.llm.prompts[-1] == "Analyze logs for: check logs now"
     assert result.response == "mock-Analyze logs for: check logs now"
+
+
+def test_config_passed_to_agents():
+    cfg = Config(database_url="sqlite:///db.sqlite")
+    orch = Orchestrator(config=cfg)
+    assert orch.log_agent.config is cfg
+    assert orch.code_agent.config is cfg
+    assert orch.db_agent.config is cfg
+    assert orch.incident_agent.config is cfg
+    assert orch.jira_agent.config is cfg


### PR DESCRIPTION
## Summary
- add `Config` dataclass and `load_config` helper
- pass configuration into agents via `Orchestrator`
- include sample `ops_config.yml`
- document configuration file usage in `README`
- test configuration loading and orchestrator config propagation

## Testing
- `pip install pyyaml`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6874ca336ec88327b7a9ea36b5e9b0dd